### PR TITLE
Cwei/fix bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+code/dependency

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 code/dependency
+code/build
+.vscode
+

--- a/README.md
+++ b/README.md
@@ -60,9 +60,24 @@ hwu --bfile NIC --hwu --screen 2 --wIBS-wt --mp 7  --PCwt 20 --out NIC.rst
 
 --screen `int`: screen SNPs using standardized HWU, and calculate p-value of highest ranked `int` SNPs (for ultra-high demensional scan)
 
-##compilation
+##compilation&build
 
-###For visual studio
+First download [Eigen](https://eigen.tuxfamily.org/index.php?title=Main_Page) and [Boost](https://www.boost.org/doc/libs/1_55_0/) under code/dependency. Unzip both, and then install boost by following steps [here](https://www.boost.org/doc/libs/1_55_0/more/getting_started/unix-variants.html#easy-build-and-install).
+
+###For g++
+
+For release:
+    g++ -static -L dependency/boost_1_55_0/stage/lib -I dependency/eigen-3.4.0 -I dependency/boost_1_55_0 -pthread -msse2 *.cpp -lboost_system -lboost_thread -lrt -w -O3 -o build/hwu
+
+For debug:
+    g++ -static -L dependency/boost_1_55_0/stage/lib -I dependency/eigen-3.4.0 -I dependency/boost_1_55_0 -pthread -msse2 -g *.cpp -lboost_system -lboost_thread -lrt -w -O3 -o build/hwu_debug
+
+###For VS code
+
+Follow steps [here](https://code.visualstudio.com/docs/cpp/introvideos-cpp). And refer to above g++ for args needed in corresponding json config.
+
+
+###For visual studio (2015 version, outdated)
 
 Make sure you compile with optimization enabled. This can easily gain you a factor of ten or more.
 
@@ -81,6 +96,4 @@ need to build boost lib
     run b2
     go to properties->linker->general->additional library, add "$Root$\boost\boost_1_55_0\stage\lib"
 
-###For g++
 
-    g++ -static -L boost_1_55_0/stage/lib -I eigen -I boost_1_55_0 -pthread -msse2 *.cpp -lboost_system -lboost_thread -lrt -w -O3 -o hwu

--- a/code/HWUeigen.cpp
+++ b/code/HWUeigen.cpp
@@ -137,6 +137,8 @@ void egHWU::sgLocusAssoc()
 		x.clear();
 		//cout<<":"<<(_datafile->getLocus(i))->name;
 		prepareX(i,x);
+		// cout<<Stat_fuc::mean(x)<<"\n";
+		// cout<<Stat_fuc::norm(x)<<"\n";
 
 		pvalue=hwu_liu(x);
 
@@ -708,13 +710,18 @@ double egHWU::hwu_inter(vector<double> & x, GTmat_ & Wt)
 		}
 	}
 
-	//cout<<_Y.sum()<<"\n";
-	//cout<<_Y.squaredNorm()<<"\n";
+	// cout<<_Y.sum()<<"\n";
+	// cout<<_Y.squaredNorm()<<"\n";
+	// cout<<Wt.sum()<<"\n";
+	// cout<<Wt.squaredNorm()<<"\n";
 
 	double U= (_Y.transpose() * (Wt * _Y) ).sum();
 
 	Wt=Wt-(_X*_XXinv)*(_X.transpose()*Wt);
 	Wt=Wt-(Wt*_X)*(_XXinv*_X.transpose());
+
+	// cout<<Wt.sum()<<"\n";
+	// cout<<Wt.squaredNorm()<<"\n";
 
 	return U;
 }

--- a/code/HWUeigen.cpp
+++ b/code/HWUeigen.cpp
@@ -139,7 +139,6 @@ void egHWU::sgLocusAssoc()
 		prepareX(i,x);
 		// cout<<Stat_fuc::mean(x)<<"\n";
 		// cout<<Stat_fuc::norm(x)<<"\n";
-
 		pvalue=hwu_liu(x);
 
 		_vec_pvalue.push_back(pvalue);
@@ -900,6 +899,14 @@ double egHWU::hwu_inter_stdUfloat(vector<float> & x)
 
 double egHWU::hwu_liu(vector<double> & x)
 {
+	if(Stat_fuc::norm(x) < 1e-10){
+		_df_vec.push_back(-1);
+		_ncp_vec.push_back(-1);
+		_q_vec.push_back(-1);
+		_weightU.push_back(0);
+		return 0.5;
+	}
+
 	GTmat_ Wt;
 
 	double U=hwu_inter(x,Wt);

--- a/code/calculate.cpp
+++ b/code/calculate.cpp
@@ -289,6 +289,17 @@ double Stat_fuc::sum(vector<double> & arr)
 	return tmp;
 }
 
+double Stat_fuc::norm(vector<double> & arr)
+{
+	double tmp=0;
+	for(int i=0; i<arr.size(); i++){
+		tmp+=arr[i]*arr[i];
+	}
+	if(arr.size()>0) tmp/=double(arr.size());
+	
+	return tmp;
+}
+
 double Stat_fuc::gammp(const double a, const double x)
 {
 	double gamser,gammcf,gln;

--- a/code/calculate.h
+++ b/code/calculate.h
@@ -80,6 +80,7 @@ namespace Stat_fuc
 	bool emprical_CI(vector<double> & arr, double & Upper, double & Lower, double pct);
 	double median(vector<double> & arr);
 	double mean(vector<double> & arr);
+	double norm(vector<double> &arr);
 	double sum(vector<double> & arr);
 	void indexx(vector<double> &arr, vector<int> & indx);
 

--- a/code/hwu.cpp
+++ b/code/hwu.cpp
@@ -965,6 +965,12 @@ void HWU::prepareX(int i_snp, vector<double> &x)
 		if(tst_minor>1.0) x[x_rcd[i]]=2-tst_minor;
 		else x[x_rcd[i]]=tst_minor;
 	}
+
+	//avoid 0 matrix (in case only a few SNP is >0)
+	double miu = (tst_minor>1.0) ? 2-tst_minor : tst_minor;
+	if(par::gsim_add){
+		for(int i=0; i<x.size(); i++) x[i]=x[i]-miu;
+	}
 }
 
 double HWU::hwu_i(int i_snp)


### PR DESCRIPTION
This is to fix a bug where the rare variants lead to (adjusted) genetic distant matrix becomes all zero. This happens when using additive kernel, ie, dist = x_i * x_j. Addtional logic is added to fix this, i.e., instead of using original x, we use the x-mean(x). 

Also updated readme for comple and build instruction.